### PR TITLE
excluded vxlan interface from physical network mappings

### DIFF
--- a/rpc_deployment/roles/neutron_common/templates/plugins/ml2/ml2_conf.ini
+++ b/rpc_deployment/roles/neutron_common/templates/plugins/ml2/ml2_conf.ini
@@ -30,7 +30,7 @@
       {%- if network_flat_networks.append(net.network.net_name) %}{%- endif %}
     {%- endif %}
   {%- endif %}
-  {% if net.network.type != 'raw' %}
+  {% if net.network.type != 'raw' and net.network.type != 'vxlan' %}
     {%- set map_pair = [] %}
     {%- if 'net_name' in net.network %}
       {%- if map_pair.append(net.network.net_name) %}{%- endif %}


### PR DESCRIPTION
This PR removes the vxlan physical interface mappings in the ml2_conf.ini, which is not needed (Please double check me on this)
It could also cause problems with starting neutron when running RPC on a consolidated architecture i.e. running all traffic over br-mgmt, in which case the mappings would be vxlan:br-mgmt,vlan:br-mgmt. The neutron agent would then throw an error like: 

ERROR neutron.plugins.linuxbridge.agent.linuxbridge_neutron_agent [-] Parsing physical_interface_mappings failed: Value br-mgmt in mapping: 'vxlan:br-mgmt' not unique. Agent terminated!

-Alex
