### PR TITLE
nova.openstack.common.rpc.impl_kombu is depricated in Liberty

### DIFF
--- a/playbooks/roles/os_nova/defaults/main.yml
+++ b/playbooks/roles/os_nova/defaults/main.yml
@@ -55,7 +55,7 @@ nova_rabbitmq_userid: nova
 nova_rabbitmq_vhost: /nova
 
 ## RPC
-nova_rpc_backend: nova.openstack.common.rpc.impl_kombu
+nova_rpc_backend: rabbit 
 nova_rpc_thread_pool_size: 64
 nova_rpc_conn_pool_size: 30
 nova_rpc_response_timeout: 60


### PR DESCRIPTION
nova_rpc_backend variable is set to nova.openstack.common.rpc.impl_kombu in openstack-ansible/playbooks/roles/os_nova/defaults/main.yml

According nova documentation for Liberty : http://docs.openstack.org/liberty/config-reference/content/configuring-rpc.html
The rpc_backend option is not required as long as RabbitMQ is the default messaging system. However, if it is included the configuration, you must set it to rabbit:
rpc_backend=rabbit

Should also be applied to liberty branch.