### PR TITLE
fix:add scope project when get token

### DIFF
--- a/scripts/federated-login.sh
+++ b/scripts/federated-login.sh
@@ -67,7 +67,8 @@ fi
 echo Performing federated login...
 
 # obtain a scoped token from the identity provider
-curl -v -s -X POST -H "Content-Type: application/json" -d '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"'"$OS_USERNAME"'","password":"'"$OS_PASSWORD"'","domain":{"name":"'"$OS_USER_DOMAIN_NAME"'"}}}}}}' $OS_AUTH_URL/auth/tokens >token.json 2>token.txt
+curl -v -s -X POST -H "Content-Type: application/json" -d '{"auth":{"scope": {"project":{"domain": {"name": "'"$OS_DOMAIN_NAME"'"}, "name": "'"$OS_PROJECT_NAME"'"}},"identity":{"methods":["password"],"password":{"user":{"name":"'"$OS_USERNAME"'","password":"'"$OS_PASSWORD"'","domain":{"name":"'"$OS_DOMAIN_NAME"'"}}}}}}' $OS_AUTH_URL/auth/tokens >token.json 2>token.txt
+
 if [ "$?" != "0" ]; then
     echo "Could not obtain IdP token, did you forget to import your openrc file? See token.json and error.log for details."
     exit 1


### PR DESCRIPTION
I had run script in my k2k system.
When i get token. It have to need **scope "project"**.
if it haven't scope "project", it will report error: "_You are not authorized to perform the requested action: Use a project scoped token when attempting to create a SAML assertion"_ in step "request a SAML2 assertion"