### PR TITLE
use string for openstack_host_systat_enabled user variable

### DIFF
--- a/playbooks/roles/openstack_hosts/defaults/main.yml
+++ b/playbooks/roles/openstack_hosts/defaults/main.yml
@@ -16,7 +16,7 @@
 openstack_code_name: 1AndOne=11
 openstack_release: master
 
-openstack_host_systat_enabled: true
+openstack_host_systat_enabled: "true"
 openstack_host_systat_interval: 1
 openstack_host_systat_statistics_hour: 23
 


### PR DESCRIPTION
sysstat requires lowercase true/false in /etc/default/sysstat.  Control this by using a string instead of the python built-in truth value.