### PR TITLE
Fix broken link for lxc_hosts role

### DIFF
--- a/doc/source/install-guide/overview-security.rst
+++ b/doc/source/install-guide/overview-security.rst
@@ -31,7 +31,7 @@ that each LXC container may take on a system.  This is done within the
 .. _security modules: https://en.wikipedia.org/wiki/Linux_Security_Modules
 .. _mandatory access controls: https://en.wikipedia.org/wiki/Mandatory_access_control
 .. _AppArmor: https://en.wikipedia.org/wiki/AppArmor
-.. _lxc_hosts role: https://github.com/openstack/openstack-ansible/blob/master/playbooks/roles/lxc_hosts/templates/lxc-openstack.apparmor.j2
+.. _lxc_hosts role: https://github.com/openstack/openstack-ansible/blob/liberty/playbooks/roles/lxc_hosts/templates/lxc-openstack.apparmor.j2
 
 Encrypted communication
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Link pointed to master, which is now missing.  Change to liberty branch