### PR TITLE
Update prepare_loopback_swap.yml

### DIFF
--- a/tests/roles/bootstrap-host/tasks/prepare_loopback_swap.yml
+++ b/tests/roles/bootstrap-host/tasks/prepare_loopback_swap.yml
@@ -40,8 +40,8 @@
     src: /openstack/swap.img
     fstype: swap
     opts: sw
-    passno: 0
-    dump: 0
+    passno: '0'
+    dump: '0'
     state: present
   tags:
     - swap-fstab

--- a/tests/roles/bootstrap-host/tasks/prepare_loopback_swift.yml
+++ b/tests/roles/bootstrap-host/tasks/prepare_loopback_swift.yml
@@ -44,8 +44,8 @@
     src: "/openstack/{{ item }}.img"
     fstype: xfs
     opts: 'loop,noatime,nodiratime,nobarrier,logbufs=8'
-    passno: 0
-    dump: 0
+    passno: '0'
+    dump: '0'
     state: mounted
   with_items:
     - 'swift1'


### PR DESCRIPTION
The task will fail with the following error:

```bash
TASK [bootstrap-host : Ensure that the swap file entry is in /etc/fstab] *******
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'int' object has no attribute 'replace'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "parsed": false}
```
[Apparently](https://github.com/ansible/ansible-modules-core/issues/1868) this is an issue in the core ansible module `mount`. Single quoting the int values (changing to string) solves the problem.