### PR TITLE
Bugs in inventory-manage scripts that caused errors

### DIFF
--- a/lib/manage.py
+++ b/lib/manage.py
@@ -25,6 +25,8 @@ import prettytable
 import dictutils as du
 import filesystem as filesys
 
+import os.path
+
 
 def args():
     """Setup argument Parsing."""
@@ -332,7 +334,7 @@ def main():
         du.recursive_dict_removal(inventory, user_args['remove_item'])
         inventory_json = json.dumps(inventory, indent=2,
                                     separators=(',', ': '))
-        filesys.save_inventory(inventory_json, filename)
+        filesys.save_inventory(inventory_json, os.path.dirname(filename))
         print('Success. . .')
 
 if __name__ == "__main__":

--- a/lib/manage.py
+++ b/lib/manage.py
@@ -331,7 +331,7 @@ def main():
     else:
         du.recursive_dict_removal(inventory, user_args['remove_item'])
         inventory_json = json.dumps(inventory, indent=2,
-                                    seprators=(',', ': '))
+                                    separators=(',', ': '))
         filesys.save_inventory(inventory_json, filename)
         print('Success. . .')
 


### PR DESCRIPTION
Fixed a syntax error with 'seprator' instead of 'separator'.

save_inventory requires a path, not a filename. Probably a bit hacky fix, but I wanted to make sure it worked in the final release.

Errors occurred when you ran a command like this:
scripts/inventory-manage.py -r log1