### PR TITLE
Added check for ipv4 variable

### DIFF
--- a/playbooks/common-tasks/dynamic-address-fact.yml
+++ b/playbooks/common-tasks/dynamic-address-fact.yml
@@ -29,7 +29,7 @@
       {%- else -%}
       {%-   set _bridge = 'no_bridge_defined' -%}
       {%- endif -%}
-      {%- if _bridge != 'no_bridge_defined' -%}
+      {%- if _bridge != 'no_bridge_defined' and hostvars[inventory_hostname]['ansible_' + _bridge]['ipv4'] is defined-%}
       {{ hostvars[inventory_hostname]['ansible_' + _bridge]['ipv4']['address'] }}
       {%- elif _network_data['address'] is defined -%}
       {{ _network_data['address'] }}


### PR DESCRIPTION
I ran into a case with my setup that everything up to the key 'ipv4' existed but 'ipv4' does not and it errored out. This check beforehand for it's existence resolved that.