### PR TITLE
avoid retrieving IP from a bridge without IP

### DIFF
--- a/playbooks/common-tasks/dynamic-address-fact.yml
+++ b/playbooks/common-tasks/dynamic-address-fact.yml
@@ -29,7 +29,7 @@
       {%- else -%}
       {%-   set _bridge = 'no_bridge_defined' -%}
       {%- endif -%}
-      {%- if _bridge != 'no_bridge_defined' -%}
+      {%- if _bridge != 'no_bridge_defined' and hostvars[inventory_hostname]['ansible_' + _bridge]['ipv4'] is defined-%}
       {{ hostvars[inventory_hostname]['ansible_' + _bridge]['ipv4']['address'] }}
       {%- elif _network_data['address'] is defined -%}
       {{ _network_data['address'] }}


### PR DESCRIPTION
In some cases, bridges are defined without static IP address.
This patch checks if the bridge has an IP, otherwise skip to the next method to determine node IP.