### PR TITLE
Add double-quotes to $BOOTSTRAP_OPTS parameter

### DIFF
--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -35,7 +35,7 @@ pushd tests
   else
     /opt/ansible-runtime/bin/ansible-playbook bootstrap-aio.yml \
                      -i test-inventory.ini \
-                     -e ${BOOTSTRAP_OPTS}
+                     -e "${BOOTSTRAP_OPTS}"
   fi
 popd
 


### PR DESCRIPTION
When using more than one value in the $BOOTSTRAP_OPTS variable, the script fails. Double quotes fixes this.